### PR TITLE
fix zero error in Chinese

### DIFF
--- a/memoryCheck.sh
+++ b/memoryCheck.sh
@@ -10,7 +10,7 @@ echo ""
 
 # Check SWAP oversold
 memSize=`free -m | awk '/Mem/ {print $2}'`
-speed=`dd if=/dev/zero of=/dev/null bs=1M count=$memSize 2>&1 | awk '/copied/ {print $(NF-1)}'`
+speed=`dd if=/dev/zero of=/dev/null bs=1M count=$memSize 2>&1 | awk '{print $(NF-1)}' | awk 'END {print}' | awk -F '，' '{print $NF}'`
 speed=`echo $speed | awk '{printf("%.0f\n",$1)}'`
 echo "内存io速度: $speed GB/s"
 echo ""


### PR DESCRIPTION
In Chinese environment, this script will output a wrong speed 0GB/s which is absurd.
```bash
[root@localhost ~]# curl https://raw.githubusercontent.com/uselibrary/memoryCheck/main/memoryCheck.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1223  100  1223    0     0   1548      0 --:--:-- --:--:-- --:--:--  1548
内存超售检测开始......

内存io速度: 0 GB/s

SWAP超售!
内存io速度低于 10 GB/s，存在SWAP超售可能

balloon超售!
存在virtio_balloon模块，使用气球驱动Balloon超售内存

未使用KSM超售，Kernel Samepage Merging状态正常，
```

After fixing Line13, it shows as expected.(Chinese)
```bash
[root@localhost ~]# dd if=/dev/zero of=/dev/null bs=1M count=180 2>&1
记录了180+0 的读入
记录了180+0 的写出
188743680字节(189 MB)已复制，0.0147549 秒，12.8 GB/秒
[root@localhost ~]# bash 1.sh 
内存超售检测开始......

内存io速度: 16 GB/s

未使用SWAP超售，内存io速度正常

balloon超售!
存在virtio_balloon模块，使用气球驱动Balloon超售内存

未使用KSM超售，Kernel Samepage Merging状态正常，
```

(English)
```bash
[root@localhost ~]# dd if=/dev/zero of=/dev/null bs=1M count=180 2>&1 
180+0 records in
180+0 records out
188743680 bytes (189 MB) copied, 0.0124579 s, 15.2 GB/s
[root@localhost ~]# bash 1.sh 
内存超售检测开始......

内存io速度: 15 GB/s

未使用SWAP超售，内存io速度正常

balloon超售!
存在virtio_balloon模块，使用气球驱动Balloon超售内存

未使用KSM超售，Kernel Samepage Merging状态正常，
```